### PR TITLE
update init to use a profile directory in home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN \
   tar xf \
     /tmp/mullvad.tar.xz -C \
     /app --strip-components=1 && \
+  mkdir /app/Data && \
+  chmod 777 /app/Data && \
   find /app -perm 700 -exec chmod 755 {} + && \
   find /app -perm 600 -exec chmod 644 {} + && \
   sed -i 's|</applications>|  <application title="Mullvad Browser" type="normal">\n    <maximized>yes</maximized>\n  </application>\n</applications>|' /etc/xdg/openbox/rc.xml && \

--- a/root/app/Browser/mullvadbrowser-lsio
+++ b/root/app/Browser/mullvadbrowser-lsio
@@ -1,0 +1,2 @@
+#!/bin/bash
+/app/Browser/mullvadbrowser -profile $HOME/lsio ${HOMEPAGE}

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,9 @@
-/app/Browser/mullvadbrowser ${HOMEPAGE}
+#!/bin/bash
+
+# Default folder
+if [ ! -f $HOME/lsio ]; then
+  mkdir $HOME/lsio
+fi
+
+# Start app
+/app/Browser/mullvadbrowser-lsio

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -2,6 +2,6 @@
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
-<item label="Mullvad Browser" icon="/app/Browser/browser/chrome/icons/default/default48.png"><action name="Execute"><command>/app/Browser/mullvadbrowser</command></action></item>
+<item label="Mullvad Browser" icon="/app/Browser/browser/chrome/icons/default/default48.png"><action name="Execute"><command>/app/Browser/mullvadbrowser-lsio</command></action></item>
 </menu>
 </openbox_menu>


### PR DESCRIPTION
This puts the users profile directory into persistent storage (/config) and works with kasminit. Just a simple wrapper for execution and the addition of the Data directory as 777 at build time as that is used as a cache directory and cannot be modified with CLI flags. 
Kasminit test FYI: 
`docker run --rm -it -p 6901:6901 --entrypoint /kasminit --user 1000 yourimagename`
https://localhost:6901
user:kasm_user
pass:vncpassword